### PR TITLE
Fix single args function

### DIFF
--- a/examples/problem_definition.jl
+++ b/examples/problem_definition.jl
@@ -185,8 +185,8 @@ problem.group = group
 func2 = GetDP.Function() # Use qualified name as established previously
 
 # Define constants
-add!(func2, "mu0", expression="4.e-7 * Pi")
-add!(func2, "eps0", expression="8.854187818e-12")
+add_constant!(func2, "mu0", "4.e-7 * Pi")
+add_constant!(func2, "eps0", "8.854187818e-12")
 add_space!(func2)
 
 # Define properties for general regions

--- a/src/function.jl
+++ b/src/function.jl
@@ -44,7 +44,7 @@ function add!(func::Function, id; expression, arguments=String[], region=String[
     # Format the identifier
     if !isempty(region)
         region_str = make_args(region)
-        id_str = "$(id)[Region[{$(region_str)}]]"
+        id_str = "$(id)[Region[$(region_str)]]"
     else
         id_str = "$(id)[]"
     end

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -72,7 +72,7 @@ function make_args(glist; sep::String=", ", list_char::Bool=false)
 
     if isa(glist, Array)
         if length(glist) == 1
-            return string(glist[1])
+            return "{" * string(glist[1]) * "}"
         else
             formatted = join([string(g) for g in glist], sep)
             return list_char ? "#{$formatted}" : "{$formatted}"

--- a/test/references/function.txt
+++ b/test/references/function.txt
@@ -1,7 +1,7 @@
 
 Function{
-  mu0[] = 4.e-7 * Pi;
-  eps0[] = 8.854187818e-12;
+  mu0 = 4.e-7 * Pi;
+  eps0 = 8.854187818e-12;
 
   nu[Region[{Air}]] = 1./mu0;
   nu[Region[{Soil_Layer1}]] = 1./(mu0*soil_mu1);

--- a/test/references/group.txt
+++ b/test/references/group.txt
@@ -1,100 +1,100 @@
 
 Group{
-  Air = Region[ AIR_ABOVE_SOIL ];
-  AirInCable = Region[ AIR_IN_CABLE ];
-  Soil_Layer1 = Region[ LAYER1 ];
+  Air = Region[ {AIR_ABOVE_SOIL} ];
+  AirInCable = Region[ {AIR_IN_CABLE} ];
+  Soil_Layer1 = Region[ {LAYER1} ];
 
-  Cond1_core_wirearray15 = Region[ 1115 ];
-  Cond1_core_semicon2 = Region[ 1120 ];
-  Cond1_core_insulator3 = Region[ 1130 ];
-  Cond1_core_semicon4 = Region[ 1140 ];
-  Cond1_core_semicon5 = Region[ 1150 ];
-  Cond1_sheath_wirearray11 = Region[ 1211 ];
-  Cond1_sheath_strip12 = Region[ 1212 ];
-  Cond1_sheath_semicon2 = Region[ 1220 ];
-  Cond1_jacket_tubular11 = Region[ 1311 ];
-  Cond1_jacket_insulator2 = Region[ 1320 ];
-  Cond1_jacket_insulator3 = Region[ 1330 ];
+  Cond1_core_wirearray15 = Region[ {1115} ];
+  Cond1_core_semicon2 = Region[ {1120} ];
+  Cond1_core_insulator3 = Region[ {1130} ];
+  Cond1_core_semicon4 = Region[ {1140} ];
+  Cond1_core_semicon5 = Region[ {1150} ];
+  Cond1_sheath_wirearray11 = Region[ {1211} ];
+  Cond1_sheath_strip12 = Region[ {1212} ];
+  Cond1_sheath_semicon2 = Region[ {1220} ];
+  Cond1_jacket_tubular11 = Region[ {1311} ];
+  Cond1_jacket_insulator2 = Region[ {1320} ];
+  Cond1_jacket_insulator3 = Region[ {1330} ];
 
-  Cond2_core_wirearray15 = Region[ 2115 ];
-  Cond2_core_semicon2 = Region[ 2120 ];
-  Cond2_core_insulator3 = Region[ 2130 ];
-  Cond2_core_semicon4 = Region[ 2140 ];
-  Cond2_core_semicon5 = Region[ 2150 ];
-  Cond2_sheath_wirearray11 = Region[ 2211 ];
-  Cond2_sheath_strip12 = Region[ 2212 ];
-  Cond2_sheath_semicon2 = Region[ 2220 ];
-  Cond2_jacket_tubular11 = Region[ 2311 ];
-  Cond2_jacket_insulator2 = Region[ 2320 ];
-  Cond2_jacket_insulator3 = Region[ 2330 ];
+  Cond2_core_wirearray15 = Region[ {2115} ];
+  Cond2_core_semicon2 = Region[ {2120} ];
+  Cond2_core_insulator3 = Region[ {2130} ];
+  Cond2_core_semicon4 = Region[ {2140} ];
+  Cond2_core_semicon5 = Region[ {2150} ];
+  Cond2_sheath_wirearray11 = Region[ {2211} ];
+  Cond2_sheath_strip12 = Region[ {2212} ];
+  Cond2_sheath_semicon2 = Region[ {2220} ];
+  Cond2_jacket_tubular11 = Region[ {2311} ];
+  Cond2_jacket_insulator2 = Region[ {2320} ];
+  Cond2_jacket_insulator3 = Region[ {2330} ];
 
-  Cond3_core_wirearray15 = Region[ 3115 ];
-  Cond3_core_semicon2 = Region[ 3120 ];
-  Cond3_core_insulator3 = Region[ 3130 ];
-  Cond3_core_semicon4 = Region[ 3140 ];
-  Cond3_core_semicon5 = Region[ 3150 ];
-  Cond3_sheath_wirearray11 = Region[ 3211 ];
-  Cond3_sheath_strip12 = Region[ 3212 ];
-  Cond3_sheath_semicon2 = Region[ 3220 ];
-  Cond3_jacket_tubular11 = Region[ 3311 ];
-  Cond3_jacket_insulator2 = Region[ 3320 ];
-  Cond3_jacket_insulator3 = Region[ 3330 ];
+  Cond3_core_wirearray15 = Region[ {3115} ];
+  Cond3_core_semicon2 = Region[ {3120} ];
+  Cond3_core_insulator3 = Region[ {3130} ];
+  Cond3_core_semicon4 = Region[ {3140} ];
+  Cond3_core_semicon5 = Region[ {3150} ];
+  Cond3_sheath_wirearray11 = Region[ {3211} ];
+  Cond3_sheath_strip12 = Region[ {3212} ];
+  Cond3_sheath_semicon2 = Region[ {3220} ];
+  Cond3_jacket_tubular11 = Region[ {3311} ];
+  Cond3_jacket_insulator2 = Region[ {3320} ];
+  Cond3_jacket_insulator3 = Region[ {3330} ];
 
   Cond1_sheath_C = Region[ {Cond1_sheath_wirearray11,  Cond1_sheath_strip12} ];
-  Cond1_jacket_C = Region[ Cond1_jacket_tubular11 ];
+  Cond1_jacket_C = Region[ {Cond1_jacket_tubular11} ];
   Cond1_C = Region[ {Cond1_sheath_C,  Cond1_jacket_C} ];
   Cond2_sheath_C = Region[ {Cond2_sheath_wirearray11,  Cond2_sheath_strip12} ];
-  Cond2_jacket_C = Region[ Cond2_jacket_tubular11 ];
+  Cond2_jacket_C = Region[ {Cond2_jacket_tubular11} ];
   Cond2_C = Region[ {Cond2_sheath_C,  Cond2_jacket_C} ];
   Cond3_sheath_C = Region[ {Cond3_sheath_wirearray11,  Cond3_sheath_strip12} ];
-  Cond3_jacket_C = Region[ Cond3_jacket_tubular11 ];
+  Cond3_jacket_C = Region[ {Cond3_jacket_tubular11} ];
   Cond3_C = Region[ {Cond3_sheath_C,  Cond3_jacket_C} ];
 
 
   Cond1_core_CC = Region[ {Cond1_core_semicon2,  Cond1_core_insulator3,  Cond1_core_semicon4,  Cond1_core_semicon5} ];
-  Cond1_sheath_CC = Region[ Cond1_sheath_semicon2 ];
+  Cond1_sheath_CC = Region[ {Cond1_sheath_semicon2} ];
   Cond1_jacket_CC = Region[ {Cond1_jacket_insulator2,  Cond1_jacket_insulator3} ];
   Cond1_CC = Region[ {Cond1_core_CC,  Cond1_sheath_CC,  Cond1_jacket_CC} ];
   Cond2_core_CC = Region[ {Cond2_core_semicon2,  Cond2_core_insulator3,  Cond2_core_semicon4,  Cond2_core_semicon5} ];
-  Cond2_sheath_CC = Region[ Cond2_sheath_semicon2 ];
+  Cond2_sheath_CC = Region[ {Cond2_sheath_semicon2} ];
   Cond2_jacket_CC = Region[ {Cond2_jacket_insulator2,  Cond2_jacket_insulator3} ];
   Cond2_CC = Region[ {Cond2_core_CC,  Cond2_sheath_CC,  Cond2_jacket_CC} ];
   Cond3_core_CC = Region[ {Cond3_core_semicon2,  Cond3_core_insulator3,  Cond3_core_semicon4,  Cond3_core_semicon5} ];
-  Cond3_sheath_CC = Region[ Cond3_sheath_semicon2 ];
+  Cond3_sheath_CC = Region[ {Cond3_sheath_semicon2} ];
   Cond3_jacket_CC = Region[ {Cond3_jacket_insulator2,  Cond3_jacket_insulator3} ];
   Cond3_CC = Region[ {Cond3_core_CC,  Cond3_sheath_CC,  Cond3_jacket_CC} ];
 
   Sur_Dirichlet_Ele = Region[ {} ];
 
-  Sur_Dirichlet_Mag = Region[ OUTBND_EM1 ];// n.b=0 on this boundary
+  Sur_Dirichlet_Mag = Region[ {OUTBND_EM1} ];// n.b=0 on this boundary
 
   DomainS0_Mag = Region[ {} ];// UNUSED
   DomainS_Mag = Region[ {} ];// UNUSED
   DomainCWithI_Mag = Region[ {} ];// If source massive
 
-  Ind_1 = Region[ 1115 ];
-  Ind_2 = Region[ 2115 ];
-  Ind_3 = Region[ 3115 ];
+  Ind_1 = Region[ {1115} ];
+  Ind_2 = Region[ {2115} ];
+  Ind_3 = Region[ {3115} ];
   Inds = Region[ {1115,  2115,  3115} ];
   Cable = Region[ {Inds,  Cond1_CC,  Cond2_CC,  Cond3_CC,  Cond1_C,  Cond2_C,  Cond3_C} ];
 
   Cable_1 = Region[ {Ind_1,  Cond1_CC,  Cond1_C} ];
   Cable_2 = Region[ {Ind_2,  Cond2_CC,  Cond2_C} ];
   Cable_3 = Region[ {Ind_3,  Cond3_CC,  Cond3_C} ];
-  DomainCWithI_Mag += Region[ Inds ];// If source massive
+  DomainCWithI_Mag += Region[ {Inds} ];// If source massive
 
-  Soil_Layer1 += Region[ INFINITY_GROUND ];
-  DomainInf = Region[ INFINITY_GROUND ];
+  Soil_Layer1 += Region[ {INFINITY_GROUND} ];
+  DomainInf = Region[ {INFINITY_GROUND} ];
 
-  DomainCC_Mag = Region[ DomainS_Mag ];
+  DomainCC_Mag = Region[ {DomainS_Mag} ];
   DomainCC_Mag += Region[ {Air,  AirInCable,  Soil_Layer1,  Cond1_CC,  Cond2_CC,  Cond3_CC} ];
 
   DomainC_Mag = Region[ {DomainCWithI_Mag,  Cond1_C,  Cond2_C,  Cond3_C} ];
 
   Domain_Mag = Region[ {DomainCC_Mag,  DomainC_Mag} ];
 
-  Domain_Ele = Region[ Cable ];// Just the cable or the same domain as magnetodynamics
+  Domain_Ele = Region[ {Cable} ];// Just the cable or the same domain as magnetodynamics
 
-  DomainDummy = Region[ 12345 ];
+  DomainDummy = Region[ {12345} ];
 
 }

--- a/test/test_function.jl
+++ b/test/test_function.jl
@@ -11,8 +11,8 @@ include("../test/normalized.jl")
     func = GetDP.Function() # Use qualified name as established previously
 
     # Define constants
-    add!(func, "mu0", expression="4.e-7 * Pi")
-    add!(func, "eps0", expression="8.854187818e-12")
+    add_constant!(func, "mu0", "4.e-7 * Pi")
+    add_constant!(func, "eps0", "8.854187818e-12")
     add_space!(func)
 
     # Define properties for general regions


### PR DESCRIPTION
When adding a single region, the string was missing an opening { and a closing }. Also, mu0 and eps0 were incorrectly treated as functions instead of constants.
I updated the tests to reflect these changes.